### PR TITLE
Add PR build verification CI and fix type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ['main']
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check_and_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Type check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,18 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # If you're using pnpm, add this step then change the commands and cache key below to use `pnpm`
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"panda": "panda"
+		"panda": "panda",
+		"prepare": "svelte-kit sync && panda codegen"
 	},
 	"devDependencies": {
 		"@fontsource/fira-mono": "^4.5.10",

--- a/src/lib/components/BlogCarousel.svelte
+++ b/src/lib/components/BlogCarousel.svelte
@@ -114,9 +114,7 @@
 		marginBottom: 'sm',
 		color: 'white',
 		lineHeight: 'tight',
-		display: '-webkit-box',
-		WebkitBoxOrient: 'vertical',
-		WebkitLineClamp: '2',
+		lineClamp: 2,
 		overflow: 'hidden'
 	});
 
@@ -145,9 +143,7 @@
 		fontSize: 'sm',
 		color: 'lightGrey',
 		lineHeight: 'normal',
-		display: '-webkit-box',
-		WebkitBoxOrient: 'vertical',
-		WebkitLineClamp: '3',
+		lineClamp: 3,
 		overflow: 'hidden'
 	});
 

--- a/src/lib/data/mockBlogData.ts
+++ b/src/lib/data/mockBlogData.ts
@@ -6,6 +6,7 @@ export const mockBlogPosts: BlogPost[] = [
 		title: 'SvelteKit と Panda CSS でモダンなWebサイトを構築する',
 		excerpt: 'SvelteKitとPanda CSSを組み合わせて、型安全でスケーラブルなWebサイトを構築する方法について解説します。',
 		date: '2024-12-16',
+		url: '/blog/sveltekit-with-panda-css',
 		slug: 'sveltekit-with-panda-css',
 		isExternal: false,
 		tags: ['SvelteKit', 'Panda CSS', 'TypeScript']
@@ -15,6 +16,7 @@ export const mockBlogPosts: BlogPost[] = [
 		title: 'フロントエンド開発における型安全性の重要性',
 		excerpt: 'TypeScriptを使ったフロントエンド開発における型安全性のメリットと実践的な活用方法について説明します。',
 		date: '2024-12-15',
+		url: '/blog/typescript-type-safety',
 		slug: 'typescript-type-safety',
 		isExternal: false,
 		tags: ['TypeScript', 'Frontend', 'Development']
@@ -24,6 +26,7 @@ export const mockBlogPosts: BlogPost[] = [
 		title: 'デザインシステムの構築とメンテナンス',
 		excerpt: '大規模なWebアプリケーションにおけるデザインシステムの構築方法と継続的なメンテナンスについて。',
 		date: '2024-12-14',
+		url: 'https://fabercompany-dev.hatenablog.com/entry/design-system',
 		slug: 'design-system-maintenance',
 		isExternal: true,
 		externalUrl: 'https://fabercompany-dev.hatenablog.com/entry/design-system',
@@ -34,6 +37,7 @@ export const mockBlogPosts: BlogPost[] = [
 		title: 'レスポンシブデザインのベストプラクティス',
 		excerpt: 'モダンなレスポンシブデザインの手法と、様々なデバイスに対応するためのベストプラクティス。',
 		date: '2024-12-13',
+		url: '/blog/responsive-design-best-practices',
 		slug: 'responsive-design-best-practices',
 		isExternal: false,
 		tags: ['Responsive Design', 'CSS', 'Mobile']
@@ -43,6 +47,7 @@ export const mockBlogPosts: BlogPost[] = [
 		title: 'React から Svelte への移行体験記',
 		excerpt: 'Reactで開発していたプロジェクトをSvelteに移行した際の体験と学んだことをまとめました。',
 		date: '2024-12-12',
+		url: '/blog/react-to-svelte-migration',
 		slug: 'react-to-svelte-migration',
 		isExternal: false,
 		tags: ['React', 'Svelte', 'Migration']

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -26,7 +26,9 @@ export const load: PageServerLoad = async ({ params }) => {
 
 export const entries: EntryGenerator = async () => {
 	const posts = await getAllInternalBlogPosts();
-	return posts.map(post => ({ slug: post.slug }));
+	return posts
+		.filter((post): post is typeof post & { slug: string } => typeof post.slug === 'string')
+		.map((post) => ({ slug: post.slug }));
 };
 
 export const prerender = true;


### PR DESCRIPTION
## Summary

- Add `ci.yml` workflow to run `pnpm check` (svelte-check) and `pnpm build` on PRs targeting `main`
- Update `deploy.yml` to use pnpm 10 + Node 22 (aligned with local environment and lockfile v9.0)
- Fix pre-existing type errors that would block CI (missing `url` property in mock data, `EntryGenerator` type mismatch, invalid Panda CSS properties)

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | New CI workflow for PR build verification |
| `.github/workflows/deploy.yml` | pnpm 8→10, Node 20→22, action-setup v3→v4 |
| `src/lib/data/mockBlogData.ts` | Add missing `url` property to `BlogPost` entries |
| `src/routes/blog/[slug]/+page.server.ts` | Type-safe filtering for `EntryGenerator` |
| `src/lib/components/BlogCarousel.svelte` | Replace `WebkitBoxOrient`/`WebkitLineClamp` with Panda CSS `lineClamp` |

## Test plan

- [x] `pnpm check` passes with 0 errors and 0 warnings
- [x] `pnpm build` succeeds
- [x] CI workflow runs on this PR