### PR TITLE
👷 Add workflow_dispatch trigger restricted to repository owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,12 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: 'main'
+  workflow_dispatch:
 
 jobs:
   build_site:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'kobayashik-Faber'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the deploy workflow so deploys can be triggered manually from the GitHub Actions UI without pushing a commit.
- Restrict manual triggers to the repository owner (`kobayashik-Faber`) via a `github.actor` check on the `build_site` job. Push-based runs from `main` are unaffected.

## Test plan
- [ ] After merge, open the **Deploy to GitHub Pages** workflow in the Actions tab and confirm a **Run workflow** button is shown.
- [ ] Run it as `kobayashik-Faber` and confirm the deploy succeeds and GitHub Pages is updated.
- [ ] (If feasible) Confirm a manual trigger by another collaborator would be skipped due to the `if` condition.