### PR TITLE
📝 Convert Tech Stack list to badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 ![CI](https://github.com/kobayashik-Faber/kobayashik-Faber.github.io/actions/workflows/ci.yml/badge.svg)
 
-## Tech Stack
-
-- [SvelteKit](https://kit.svelte.dev/) / [Svelte 5](https://svelte.dev/)
-- [TypeScript](https://www.typescriptlang.org/)
-- [Panda CSS](https://panda-css.com/)
-- [Vite](https://vitejs.dev/)
-- [pnpm](https://pnpm.io/)
-- [GitHub Pages](https://pages.github.com/) (adapter-static)
+[![SvelteKit](https://img.shields.io/badge/SvelteKit-FF3E00?style=flat-square&logo=svelte&logoColor=white)](https://kit.svelte.dev/)
+[![Svelte 5](https://img.shields.io/badge/Svelte%205-FF3E00?style=flat-square&logo=svelte&logoColor=white)](https://svelte.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Panda CSS](https://img.shields.io/badge/Panda%20CSS-EFC323?style=flat-square&logo=pandacss&logoColor=white)](https://panda-css.com/)
+[![Vite](https://img.shields.io/badge/Vite-646CFF?style=flat-square&logo=vite&logoColor=white)](https://vitejs.dev/)
+[![pnpm](https://img.shields.io/badge/pnpm-F69220?style=flat-square&logo=pnpm&logoColor=white)](https://pnpm.io/)
+[![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-222222?style=flat-square&logo=githubpages&logoColor=white)](https://pages.github.com/)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Replace the bulleted **Tech Stack** list with shields.io badges (with Simple Icons logos), placed below the CI status badge.
- Following the more common OSS convention of dynamic status badges first, static stack badges after. Links to each project's homepage are preserved via the badge anchors.

## Test plan
- [x] `pnpm format:check` passes
- [ ] Confirm the badges render correctly on the GitHub README preview after merge