### PR TITLE
👷 Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,7 @@ updates:
       prefix: ⬆️
     labels:
       - dependencies
+      - npm
     groups:
       svelte:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: ⬆️
+    labels:
+      - dependencies
+    groups:
+      svelte:
+        patterns:
+          - svelte
+          - '@sveltejs/*'
+          - svelte-check
+          - prettier-plugin-svelte
+          - mdsvex
+      vite:
+        patterns:
+          - vite
+      panda:
+        patterns:
+          - '@pandacss/*'
+      prettier:
+        patterns:
+          - prettier
+      typescript-tooling:
+        patterns:
+          - typescript
+          - tslib
+          - tsx
+          - '@types/*'
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ⬆️
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
Step 2 of the supply-chain hardening plan. Now that direct dependencies are pinned to exact versions, automate keeping them current so security patches still land.

### npm ecosystem
- Weekly checks
- Grouped by area to minimize review burden: `svelte`, `vite`, `panda`, `prettier`, `typescript-tooling`
- Labels: `dependencies`, `npm`
- Open PR limit: 10

### GitHub Actions ecosystem
- Weekly checks
- All actions grouped into a single PR
- Labels: `dependencies`, `github-actions`

### Conventions
- Both ecosystems use the Gitmoji `⬆️` commit prefix to stay consistent with existing history

### Next step candidate
- Cooldown / minimum-release-age — defends against rapid-release supply-chain attacks where a compromised package is published and later taken down within hours

## Test plan
- [x] `pnpm format:check` passes
- [ ] After merge, Dependabot creates the next batch of PRs on the configured schedule with the expected labels and grouping