### PR TITLE
⬆️ Upgrade pnpm to v11 for default release cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
   "dependencies": {
     "@types/xml2js": "0.4.14",
     "xml2js": "0.6.2"
-  }
+  },
+  "packageManager": "pnpm@11.4.0+sha512.f0febc7e37552ab485494a914241b338e0b3580b93d54ce31f00933015880863129038a1b4ae4e414a0ee63ac35bf21197e990172c4a68256450b5636310968f"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 engineStrict: true
 saveExact: true
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary
Step 3 of the supply-chain hardening plan. Switch to pnpm v11 to pick up its new default behavior: a 24h release cooldown for **all** dependencies (transitive included).

### Why pnpm v11
- v11 sets `minimumReleaseAge` to `1440` (24h) by default. v10 defaults to `0` (no cooldown).
- The cooldown blunts the most common supply-chain attack window — a compromised release is typically published and yanked within hours.
- Upgrading avoids hand-rolled per-repo config drift; we get the protection by default.

### Changes
- `package.json`: add `packageManager` field with SHA-512 integrity hash (added by `corepack use pnpm@11.4.0`). This becomes the single source of truth for the pnpm version.
- `.github/workflows/ci.yml` and `.github/workflows/deploy.yml`: drop the hard-coded `version: 10`. `pnpm/action-setup@v4` reads the version from `packageManager` automatically.

### Verified locally on pnpm 11.4.0
- [x] `pnpm install` — no lockfile churn (v11 reads v10 lockfile fine)
- [x] `pnpm build` — succeeds
- [x] `pnpm check` — 0 errors
- [x] `pnpm format:check` — passes
- [ ] CI on this PR is green (validates `pnpm/action-setup@v4` resolves v11.4.0 from `packageManager` on the runner)