### PR TITLE
⬆️ Upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -33,7 +33,7 @@ jobs:
           pnpm build
 
       - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # this should match the `pages` option in your adapter-static options
           path: 'build/'
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Prep work before SHA-pinning all actions. Bring three actions up to their latest major versions; the other two are already on the latest major.

### Upgrades
| Action | From | To | Notes |
| --- | --- | --- | --- |
| `pnpm/action-setup` | v4 | **v6** | v5: Node 24; v6: pnpm 11 support. `packageManager` auto-detection preserved → no `with: version` change needed |
| `actions/upload-pages-artifact` | v3 | **v5** | v4 stopped auto-including dotfiles. `build/` has no dotfiles, so default behavior is fine |
| `actions/deploy-pages` | v4 | **v5** | Node 24 runtime bump only, no input/behavior changes |

| `actions/checkout` | v6 | v6 | Already latest |
| `actions/setup-node` | v6 | v6 | Already latest |

### Notes
- A stale Dependabot branch `dependabot/github_actions/actions-*` exists from before the pnpm v11 upgrade. It would revert the `packageManager` field and `allowBuilds` config, so it is intentionally **not** used here.
- Next step: SHA-pin every action reference (`@v6` → `@<sha> # v6.0.2`) for full supply-chain integrity.

## Test plan
- [ ] CI on this PR passes
- [ ] After merge, deploy workflow succeeds end-to-end on next `main` push or manual `workflow_dispatch`