### PR TITLE
📌 Pin Node.js to v24 via package.json engines field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version-file: package.json
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version-file: package.json
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.actor == 'kobayashik-Faber'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -33,7 +33,7 @@ jobs:
           pnpm build
 
       - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # this should match the `pages` option in your adapter-static options
           path: 'build/'
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "vite": "7.3.3"
   },
   "type": "module",
+  "engines": {
+    "node": "24"
+  },
   "dependencies": {
     "@types/xml2js": "0.4.14",
     "xml2js": "0.6.2"


### PR DESCRIPTION
## Summary
Pin Node.js to **v24** as the single source of truth in `package.json`'s `engines.node`, bumping from the implicit v22.

### Why a single source of truth
`pnpm-workspace.yaml` already has `engineStrict: true`, so any `pnpm install` with a non-v24 Node hard-fails. By moving the version into `package.json`, the workflows no longer need to hard-code `22`; they read it from the same place via `node-version-file: package.json`.

### Changes
- `package.json`: add `"engines": { "node": "24" }`
- `.github/workflows/ci.yml` / `deploy.yml`: replace `node-version: 22` with `node-version-file: package.json`

### Local verification on Node 24.16.0
- [x] `pnpm install` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm check` reports 0 errors
- [x] `pnpm format:check` passes

### Heads-up for collaborators
After this lands, local development requires Node 24. With nvm:

```
nvm install 24 && nvm use 24 && nvm alias default 24
corepack enable
```

## Test plan
- [ ] CI on this PR passes (confirms `node-version-file: package.json` resolves to 24 on the runner)
- [ ] After merge, deploy workflow succeeds end-to-end